### PR TITLE
fix: use URL rewrite instead of redirect in Nignx

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -7,6 +7,8 @@ server {
     sendfile on;
     sendfile_max_chunk 1m;
 
+    rewrite ^/clamav(/.*)$ $1 last;
+
     location / {
         alias /var/lib/clamav/;
         autoindex on;
@@ -14,15 +16,8 @@ server {
         autoindex_format html;
     }
 
-    location /clamav/ {
-        absolute_redirect off;
-        return 301 /;
-    }
-
-
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
 }
-


### PR DESCRIPTION
## Description

Fix permanent redirect which was returning `404` for URLs `/clamav/*` by using internal URL `rewrite` in `nginx` configuration making it transparent from the client side.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
